### PR TITLE
Mariatcl compile updates

### DIFF
--- a/generic/mariatcl.c
+++ b/generic/mariatcl.c
@@ -981,7 +981,7 @@ static int Mariatcl_Connect(ClientData clientData, Tcl_Interp *interp, int objc,
 #if (MYSQL_VERSION_ID >= 32350)
   if (mysql_options_reconnect)
   {
-    my_bool reconnect = 1;
+    bool reconnect = 1;
     mysql_options(handle->connection, MYSQL_OPT_RECONNECT, &reconnect);
   }
   mysql_options(handle->connection, MYSQL_READ_DEFAULT_GROUP, groupname);

--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -1,5 +1,5 @@
 #
 # Tcl package index file
 #
-package ifneeded mysqltcl @PACKAGE_VERSION@ \
+package ifneeded mariatcl @PACKAGE_VERSION@ \
     [list load [file join $dir @PKG_LIB_FILE@] @PACKAGE_NAME@]


### PR DESCRIPTION
Some small changes for correct compilation. my_bool to bool is the same in mysql and update to pkgindex so it is looking for the correct file.  Have checked and verified that this works OK with a mariadb library. 